### PR TITLE
fix(nonce): override user-defined nonce values with Nuxt Image

### DIFF
--- a/src/runtime/nitro/plugins/40-cspSsrNonce.ts
+++ b/src/runtime/nitro/plugins/40-cspSsrNonce.ts
@@ -3,6 +3,7 @@ import { resolveSecurityRules } from '../context'
 import { generateRandomNonce } from '../../../utils/crypto'
 
 const LINK_RE = /<link([^>]*?>)/gi
+const NONCE_RE = /nonce="[^"]+"/i
 const SCRIPT_RE = /<script([^>]*?>)/gi
 const STYLE_RE = /<style([^>]*?>)/gi
 
@@ -58,6 +59,9 @@ export default defineNitroPlugin((nitroApp) => {
         }
         // Add nonce to all link tags
         element = element.replace(LINK_RE, (match, rest) => {
+          if (NONCE_RE.test(rest)) {
+            return match.replace(NONCE_RE, `nonce="${nonce}"`);
+          }
           return `<link nonce="${nonce}"` + rest
         })
         // Add nonce to all script tags


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Resolves #586 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
For users utilizing Nuxt Image (with its option to provide custom nonces), Nuxt Security will override the user-defined nonce to ensure standard-complying, cryptographically secure nonces.

As a side note, it is worth deprecating the nonce property in Nuxt Image regardless due to the security concerns it brings with no proportionate benefit

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
